### PR TITLE
fixbug: 修改 add方法传入id无效

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -77,7 +77,7 @@ module.exports = function(ctx, api) {
         const featureCollection = JSON.parse(JSON.stringify(normalize(geojson)));
 
         const ids = featureCollection.features.map(function(feature) {
-            feature.id = feature.id || hat();
+            feature.id = feature.geometry.id || hat();
 
             if (feature.geometry === null) {
                 throw new Error('Invalid geometry: null');


### PR DESCRIPTION
原 feature.id = feature.id || hat(); 中 feature.id 取不到传入的id,应改为feature.id = feature.geometry.id || hat();